### PR TITLE
UPDATE: Added Admin Guard and Admin decorator for role-based access c…

### DIFF
--- a/src/Common/Decorators/admin.decorator.ts
+++ b/src/Common/Decorators/admin.decorator.ts
@@ -1,0 +1,7 @@
+import { Reflector } from "@nestjs/core";
+
+const _Admin = Reflector.createDecorator<string>({
+    key: "admin"
+});
+
+export const Admin = (value: string = "admin") => _Admin(value);

--- a/src/Common/Guards/Service/admin.guard.ts
+++ b/src/Common/Guards/Service/admin.guard.ts
@@ -1,0 +1,50 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Reflector } from "@nestjs/core";
+import { JwtService } from "@nestjs/jwt";
+import { Request } from "express";
+import { Observable } from "rxjs";
+import { logger } from "src/Common/Services/logger";
+
+@Injectable()
+export class AdminGuard implements CanActivate{
+    constructor(
+        private readonly reflector: Reflector,
+        private jwtService: JwtService,
+        private configService: ConfigService
+    ){}
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const http = context.switchToHttp();
+        const request = http.getRequest<Request>();
+        
+        try{
+
+            const admin = this.reflector.get<string>('admin', context.getHandler());
+            const secret = this.configService.get<string>('ADMIN_SECRET');
+            const cookie = request.cookies['access_token'];
+
+            let token = cookie;
+
+            if(request.body.access_token && !cookie){
+                token = request.body.access_token;
+            }
+
+            if(!token) throw new UnauthorizedException('Access Token not found');
+
+            const verified = await this.jwtService.verifyAsync(token, {secret});
+
+            if(!admin || admin !== verified.role) throw new UnauthorizedException('Only the admin is allowed here');
+
+            return true;
+        }catch(error){
+            logger.error({
+                message: error?.message ?? "Admin access required",
+                error: error,
+                path: request.url,
+                userAgent: request.headers['user-agent'],
+                method: request.method
+            });
+            throw new UnauthorizedException('Access denied: invalid or missing admin token');
+        }
+    }
+}


### PR DESCRIPTION
…ontrol

- Implemented `AdminGuard` to restrict access to routes requiring admin privileges
- Created a custom `@Admin()` decorator using Reflector to define protected admin routes
- Integrated JWT verification using a configurable `ADMIN_SECRET`
- Included support for token retrieval via cookies or request body
- Added structured error logging for failed authorization attempts
- Ensured unauthorized access throws descriptive exceptions for better debugging